### PR TITLE
fix sizeof warning, which triggered SyntaxError: Unexpected token error

### DIFF
--- a/lookup.php
+++ b/lookup.php
@@ -155,10 +155,10 @@ if ($checkInputQuery) {
             }
         }
 
-        $wSize = sizeof($w) !== 0;
-        $uSize = sizeof($u) !== 0;
-        $mSize = sizeof($m) !== 0;
-        $eSize = sizeof($e) !== 0;
+        $wSize = is_array($w) && sizeof($w) !== 0;
+        $uSize = is_array($u) && sizeof($u) !== 0;
+        $mSize = is_array($m) && sizeof($m) !== 0;
+        $eSize = is_array($e) && sizeof($e) !== 0;
 
         if ($wSize || $uSize || $mSize || $eSize) {
             $return[0]["status"] = 1;


### PR DESCRIPTION
Closes #28 
Not sure if there were any other warnings/errors that could've been the cause. This was what made it work for me. Found the issue by logging the `xhr` output from the `xhrError` function in `main.js`, with the output in `responseText` having:
```
<b>Warning</b>:  sizeof(): Parameter must be an array or an object that implements Countable in <b>/www/public/lookup.php</b> on line <b>158</b><br />
<b>Warning</b>:  sizeof(): Parameter must be an array or an object that implements Countable in <b>/www/public/lookup.php</b> on line <b>160</b><br />
<b>Warning</b>:  sizeof(): Parameter must be an array or an object that implements Countable in <b>/www/public/lookup.php</b> on line <b>161</b><br />
```
Would definitely recommend better logging for end-users, or at-least an error in the console showing the `responseText` in case something similar happens again.